### PR TITLE
implement issue lifetime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ Showing a graph of postmortem issues per team to see how many days it took to
 resolve them.
 
 ```
-ceil((github_exporter_issue_closed_labels_seconds{labels=~"postmortem,team/.*"} - on(number,labels) github_exporter_issue_open_labels_seconds{labels=~"postmortem,team/.*"}) / 86400)
+histogram_quantile(0.95, github_exporter_issue_labels_lifetime_bucket)
 ```

--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ github_exporter_issue_labels_count{labels="kind/okr,goal/missed"}
 ```
 github_exporter_issue_labels_count{labels=~"kind/okr,goal/.*"}
 ```
+
+Showing a graph of postmortem issues per team to see how many days it took to
+resolve them.
+
+```
+ceil((github_exporter_issue_closed_labels_seconds{labels=~"postmortem,team/.*"} - on(number,labels) github_exporter_issue_open_labels_seconds{labels=~"postmortem,team/.*"}) / 86400)
+```

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -8,7 +8,6 @@ const (
 const (
 	labelLabel  = "label"
 	labelLabels = "labels"
-	labelNumber = "number"
 	labelOrg    = "org"
 	labelRepo   = "repo"
 	labelState  = "state"

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -8,6 +8,7 @@ const (
 const (
 	labelLabel  = "label"
 	labelLabels = "labels"
+	labelNumber = "number"
 	labelOrg    = "org"
 	labelRepo   = "repo"
 	labelState  = "state"

--- a/service/collector/issue.go
+++ b/service/collector/issue.go
@@ -3,7 +3,9 @@ package collector
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -12,7 +14,29 @@ import (
 )
 
 var (
-	issueLabelDesc *prometheus.Desc = prometheus.NewDesc(
+	issueClosedLabelSecondsDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "closed_label_seconds"),
+		"Timestamps of closed issues per label.",
+		[]string{
+			labelOrg,
+			labelRepo,
+			labelLabel,
+			labelNumber,
+		},
+		nil,
+	)
+	issueClosedLabelsSecondsDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "closed_labels_seconds"),
+		"Timestamps of closed issues per combined labels.",
+		[]string{
+			labelOrg,
+			labelRepo,
+			labelLabels,
+			labelNumber,
+		},
+		nil,
+	)
+	issueLabelCountDesc *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "label_count"),
 		"Github issues per label.",
 		[]string{
@@ -23,7 +47,7 @@ var (
 		},
 		nil,
 	)
-	issueLabelsDesc *prometheus.Desc = prometheus.NewDesc(
+	issueLabelsCountDesc *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "labels_count"),
 		"Github issues per combined labels.",
 		[]string{
@@ -34,7 +58,29 @@ var (
 		},
 		nil,
 	)
-	issueStatesDesc *prometheus.Desc = prometheus.NewDesc(
+	issueOpenLabelSecondsDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "open_label_seconds"),
+		"Timestamps of open issues per label.",
+		[]string{
+			labelOrg,
+			labelRepo,
+			labelLabel,
+			labelNumber,
+		},
+		nil,
+	)
+	issueOpenLabelsSecondsDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "open_labels_seconds"),
+		"Timestamps of open issues per combined labels.",
+		[]string{
+			labelOrg,
+			labelRepo,
+			labelLabels,
+			labelNumber,
+		},
+		nil,
+	)
+	issueStatesCountDesc *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "states_count"),
 		"Github issue states.",
 		[]string{
@@ -88,17 +134,23 @@ func (i *Issue) Collect(ch chan<- prometheus.Metric) error {
 			// https://developer.github.com/v3/search/#about-the-search-api.
 			PerPage: 1000,
 		},
+		Since: time.Now().AddDate(-1, 0, 0), // one year ago
 		State: "all",
 	}
 
 	type key struct {
-		Name  string
-		State string
+		Label  string
+		Number string
+		State  string
 	}
 
-	issueLabel := map[key]float64{}
-	issueLabels := map[key]float64{}
-	issueStates := map[string]float64{}
+	issueLabelCount := map[key]float64{}
+	issueClosedLabelSeconds := map[key]float64{}
+	issueClosedLabelsSeconds := map[key]float64{}
+	issueLabelsCount := map[key]float64{}
+	issueOpenLabelSeconds := map[key]float64{}
+	issueOpenLabelsSeconds := map[key]float64{}
+	issueStatesCount := map[string]float64{}
 
 	for {
 		issues, res, err := i.githubClient.Issues.ListByRepo(ctx, githubOrg, githubRepo, opts)
@@ -114,25 +166,51 @@ func (i *Issue) Collect(ch chan<- prometheus.Metric) error {
 			}
 
 			for _, label := range issue.Labels {
-				k := key{
-					Name:  label.GetName(),
-					State: issue.GetState(),
+				{
+					k := key{
+						Label: label.GetName(),
+						State: issue.GetState(),
+					}
+					issueLabelCount[k] = issueLabelCount[k] + 1
 				}
-				issueLabel[k] = issueLabel[k] + 1
+
+				if issue.GetState() == "closed" {
+					k := key{
+						Label:  label.GetName(),
+						Number: strconv.Itoa(issue.GetNumber()),
+						State:  issue.GetState(),
+					}
+					issueOpenLabelSeconds[k] = float64(issue.GetCreatedAt().Unix())
+					issueClosedLabelSeconds[k] = float64(issue.GetClosedAt().Unix())
+				}
 			}
 
 			for _, selector := range i.customLabels {
-				if hasLabels(issue, selector) {
+				if !hasLabels(issue, selector) {
+					continue
+				}
+
+				{
 					k := key{
-						Name:  selector,
+						Label: selector,
 						State: issue.GetState(),
 					}
-					issueLabels[k] = issueLabels[k] + 1
+					issueLabelsCount[k] = issueLabelsCount[k] + 1
+				}
+
+				if issue.GetState() == "closed" {
+					k := key{
+						Label:  selector,
+						Number: strconv.Itoa(issue.GetNumber()),
+						State:  issue.GetState(),
+					}
+					issueOpenLabelsSeconds[k] = float64(issue.GetCreatedAt().Unix())
+					issueClosedLabelsSeconds[k] = float64(issue.GetClosedAt().Unix())
 				}
 			}
 
 			{
-				issueStates[issue.GetState()] = issueStates[issue.GetState()] + 1
+				issueStatesCount[issue.GetState()] = issueStatesCount[issue.GetState()] + 1
 			}
 		}
 
@@ -147,33 +225,81 @@ func (i *Issue) Collect(ch chan<- prometheus.Metric) error {
 		opts.Page = res.NextPage
 	}
 
-	for k, v := range issueLabel {
+	for k, v := range issueClosedLabelSeconds {
 		ch <- prometheus.MustNewConstMetric(
-			issueLabelDesc,
+			issueClosedLabelSecondsDesc,
 			prometheus.GaugeValue,
 			v,
 			githubOrg,
 			githubRepo,
-			k.Name,
-			k.State,
+			k.Label,
+			k.Number,
 		)
 	}
 
-	for k, v := range issueLabels {
+	for k, v := range issueClosedLabelsSeconds {
 		ch <- prometheus.MustNewConstMetric(
-			issueLabelsDesc,
+			issueClosedLabelsSecondsDesc,
 			prometheus.GaugeValue,
 			v,
 			githubOrg,
 			githubRepo,
-			k.Name,
+			k.Label,
+			k.Number,
+		)
+	}
+
+	for k, v := range issueLabelCount {
+		ch <- prometheus.MustNewConstMetric(
+			issueLabelCountDesc,
+			prometheus.GaugeValue,
+			v,
+			githubOrg,
+			githubRepo,
+			k.Label,
 			k.State,
 		)
 	}
 
-	for k, v := range issueStates {
+	for k, v := range issueLabelsCount {
 		ch <- prometheus.MustNewConstMetric(
-			issueStatesDesc,
+			issueLabelsCountDesc,
+			prometheus.GaugeValue,
+			v,
+			githubOrg,
+			githubRepo,
+			k.Label,
+			k.State,
+		)
+	}
+
+	for k, v := range issueOpenLabelSeconds {
+		ch <- prometheus.MustNewConstMetric(
+			issueOpenLabelSecondsDesc,
+			prometheus.GaugeValue,
+			v,
+			githubOrg,
+			githubRepo,
+			k.Label,
+			k.Number,
+		)
+	}
+
+	for k, v := range issueOpenLabelsSeconds {
+		ch <- prometheus.MustNewConstMetric(
+			issueOpenLabelsSecondsDesc,
+			prometheus.GaugeValue,
+			v,
+			githubOrg,
+			githubRepo,
+			k.Label,
+			k.Number,
+		)
+	}
+
+	for k, v := range issueStatesCount {
+		ch <- prometheus.MustNewConstMetric(
+			issueStatesCountDesc,
 			prometheus.GaugeValue,
 			v,
 			githubOrg,
@@ -186,9 +312,13 @@ func (i *Issue) Collect(ch chan<- prometheus.Metric) error {
 }
 
 func (i *Issue) Describe(ch chan<- *prometheus.Desc) error {
-	ch <- issueLabelDesc
-	ch <- issueLabelsDesc
-	ch <- issueStatesDesc
+	ch <- issueClosedLabelSecondsDesc
+	ch <- issueClosedLabelsSecondsDesc
+	ch <- issueLabelCountDesc
+	ch <- issueLabelsCountDesc
+	ch <- issueOpenLabelSecondsDesc
+	ch <- issueOpenLabelsSecondsDesc
+	ch <- issueStatesCountDesc
 	return nil
 }
 

--- a/service/collector/issue.go
+++ b/service/collector/issue.go
@@ -88,9 +88,6 @@ type Issue struct {
 	githubClient *github.Client
 	logger       micrologger.Logger
 
-	issueLabelLifetimeHistogramVec  *prometheus.HistogramVec
-	issueLabelsLifetimeHistogramVec *prometheus.HistogramVec
-
 	customLabels []string
 }
 
@@ -105,9 +102,6 @@ func NewIssue(config IssueConfig) (*Issue, error) {
 	i := &Issue{
 		githubClient: config.GithubClient,
 		logger:       config.Logger,
-
-		issueLabelLifetimeHistogramVec:  issueLabelLifetimeHistogramVec,
-		issueLabelsLifetimeHistogramVec: issueLabelsLifetimeHistogramVec,
 
 		customLabels: config.CustomLabels,
 	}
@@ -163,7 +157,7 @@ func (i *Issue) Collect(ch chan<- prometheus.Metric) error {
 
 				if issue.GetState() == "closed" {
 					f := float64(issue.GetClosedAt().Unix() - issue.GetCreatedAt().Unix())
-					i.issueLabelLifetimeHistogramVec.WithLabelValues(githubOrg, githubRepo, label.GetName()).Observe(f)
+					issueLabelLifetimeHistogramVec.WithLabelValues(githubOrg, githubRepo, label.GetName()).Observe(f)
 				}
 			}
 
@@ -182,7 +176,7 @@ func (i *Issue) Collect(ch chan<- prometheus.Metric) error {
 
 				if issue.GetState() == "closed" {
 					f := float64(issue.GetClosedAt().Unix() - issue.GetCreatedAt().Unix())
-					i.issueLabelsLifetimeHistogramVec.WithLabelValues(githubOrg, githubRepo, selector).Observe(f)
+					issueLabelsLifetimeHistogramVec.WithLabelValues(githubOrg, githubRepo, selector).Observe(f)
 				}
 			}
 


### PR DESCRIPTION
With this proposal it is possible to show a graph of postmortem issues per team to see how many days it took to resolve them. Note that the obtained data is not a histogram but two timestamps for each issue. Uncertain if this is the right way. For me it was one way to get it working since the histogram magic was a huge brain fuck. 

<img width="1920" alt="screenshot 2019-02-27 at 18 17 51" src="https://user-images.githubusercontent.com/552769/53509548-4d7fe200-3abc-11e9-8f58-b10a7295ede0.png">

<img width="1920" alt="screenshot 2019-02-27 at 18 18 04" src="https://user-images.githubusercontent.com/552769/53509549-4d7fe200-3abc-11e9-9203-24a210a0995e.png">
